### PR TITLE
show "load more instances" as button

### DIFF
--- a/views/list.njk
+++ b/views/list.njk
@@ -119,7 +119,7 @@
                         <i style="display: block;" class="fa fa-refresh fa-spin fa-2x fa-fw mx-auto"></i>
                     </div>
                     <div class="card-block text-center" id="load-more-instances" style="display: none;">
-                        <a class="btn btn-primary" onclick="loadMoreInstances();">Load more</a>
+                        <a class="btn btn-primary" style="color:#fff" onclick="loadMoreInstances();">Load more</a>
                     </div>
                 </div>
             {% else %}

--- a/views/list.njk
+++ b/views/list.njk
@@ -119,7 +119,7 @@
                         <i style="display: block;" class="fa fa-refresh fa-spin fa-2x fa-fw mx-auto"></i>
                     </div>
                     <div class="card-block text-center" id="load-more-instances" style="display: none;">
-                        <a onclick="loadMoreInstances();">Load more</a>
+                        <a class="btn btn-primary" onclick="loadMoreInstances();">Load more</a>
                     </div>
                 </div>
             {% else %}


### PR DESCRIPTION
Simple style change that adds the `btn` and `btn-primary` classes to the "load more instances" button.

**before**

![image](https://user-images.githubusercontent.com/6566104/199108671-699c78ed-234d-46c2-ae81-2f669667e1a4.png)

**after**

![image](https://user-images.githubusercontent.com/6566104/199108832-19cc940d-0528-42e7-9c94-1169e7d14ff9.png)
